### PR TITLE
chore: Move from pg_cron to pg_partman

### DIFF
--- a/postgresql/12/Dockerfile
+++ b/postgresql/12/Dockerfile
@@ -78,16 +78,8 @@ RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION
 ENV POSTGRESQL_PG_PARTMAN_VERSION 4.7.2
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${POSTGRESQL_PG_PARTMAN_VERSION}.tar.gz" | tar -xz && \
 	cd pg_partman-${POSTGRESQL_PG_PARTMAN_VERSION} && \
-	make -j $(nproc) NO_BGW=1 install && \
+	make -j $(nproc) install && \
 	make clean
-
-# Install pg_cron
-ENV POSTGRESQL_PG_CRON_VERSION 1.6.0
-RUN curl -sSL "https://github.com/citusdata/pg_cron/archive/v${POSTGRESQL_PG_CRON_VERSION}.tar.gz" | tar -xz && \
-    cd pg_cron-${POSTGRESQL_PG_CRON_VERSION} && \
-    make -j $(nproc) && \
-    make -j $(nproc) install && \
-    make clean
 
 # Strip binaries and object files
 RUN install_packages binutils

--- a/postgresql/12/rootfs/docker-entrypoint-initdb.d/00-init-pg-cron.sh
+++ b/postgresql/12/rootfs/docker-entrypoint-initdb.d/00-init-pg-cron.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# N.b., any global environment variables are defined in `/opt/bitnami/postgresql-env.sh`
-echo "shared_preload_libraries = 'pg_cron'" >>"${POSTGRESQL_CONF_FILE}"
-echo "cron.database_name = '${POSTGRESQL_DATABASE:-}'" >>"${POSTGRESQL_CONF_FILE}"

--- a/postgresql/12/rootfs/docker-entrypoint-initdb.d/00-init-pg-partman.sh
+++ b/postgresql/12/rootfs/docker-entrypoint-initdb.d/00-init-pg-partman.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# N.b., any global environment variables are defined in `/opt/bitnami/postgresql-env.sh`
+echo "shared_preload_libraries = 'pg_partman_bgw'" >>"${POSTGRESQL_CONF_FILE}"
+echo "pg_partman_bgw.interval = 3600" >>"${POSTGRESQL_CONF_FILE}"
+echo "pg_partman_bgw.role = 'postgres'" >>"${POSTGRESQL_CONF_FILE}"
+echo "pg_partman_bgw.dbname = 'conductor_production'" >>"${POSTGRESQL_CONF_FILE}"


### PR DESCRIPTION
Turns out that pg_cron only supports 1 database per Postgres instance. We would need pg_cron 2.0 to support multiple DBs, but it's stuck in a branch from 2017:

https://github.com/citusdata/pg_cron/issues/36#issuecomment-342175116

Instead, we found a possible workaround with background processes in pg_partman. Trying this out for WFC.