### PR TITLE
Configure PostgreSQL image without JIT [ONPREM-831]

### DIFF
--- a/postgresql/12/Dockerfile
+++ b/postgresql/12/Dockerfile
@@ -36,7 +36,6 @@ RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/post
 		--with-libxml \
 		--with-libxslt \
 		--with-icu \
-		--with-llvm \
 		--with-lz4 && \
 	make -j $(nproc) world-bin && \
 	make -j $(nproc) install-world-bin && \


### PR DESCRIPTION
Jira: https://circleci.atlassian.net/browse/ONPREM-831

It's not available. This will also match the Bitnami PostgreSQL image that this is based on.

```
$ psql
psql (12.16)
Type "help" for help.

postgres=# SHOW jit;
 jit 
-----
 on
(1 row)

postgres=# SELECT pg_jit_available();
 pg_jit_available 
------------------
 f
(1 row)

postgres=# 

```